### PR TITLE
Remove Support to old Cordova CLI & Cordova iOS versions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,17 +33,12 @@
                 <param name="ios-package" value="IoniCordovaRTMPandHLS" />
             </feature>
         </config-file>
-        <!-- 
-            Cordova CLI > 9.0.1
-            <podspec>
-                <config>
-                    <source url="https://cdn.cocoapods.org/" />
-                    <pod name="HaishinKit" spec="~> 1.5.6" />
-                </config>
-            </podspec>
-        -->
-        <!-- Cordova CLI <= 9.0.1 -->
-        <framework src="HaishinKit" type="podspec" spec="~> 1.5.6" />
+        <podspec>
+            <config>
+                <source url="https://cdn.cocoapods.org/" />
+                <pod name="HaishinKit" spec="~> 1.5.6" />
+            </config>
+        </podspec>
         <framework src="AVFoundation.framework" weak="true" />
         
         <source-file src="src/ios/IoniCordovaRTMPandHLS.swift" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,10 +34,9 @@
             </feature>
         </config-file>
         <podspec>
-            <config>
-                <source url="https://cdn.cocoapods.org/" />
+            <pods>
                 <pod name="HaishinKit" spec="~> 1.5.6" />
-            </config>
+            </pods>
         </podspec>
         <framework src="AVFoundation.framework" weak="true" />
         


### PR DESCRIPTION
Remove Support to old Cordova versions (cordova CLI and cordova ios)
This should support Cordova CLI > 9.0.1 and Cordova iOS > 6.2.0