### PR TITLE
Fix Stop broadcasting crash (iOS/Android) and set VideoSize on Android Playback 

### DIFF
--- a/src/android/IoniCordovaRTMPandHLS.java
+++ b/src/android/IoniCordovaRTMPandHLS.java
@@ -21,6 +21,7 @@ import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.hls.HlsMediaSource;
+import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
 import com.google.android.exoplayer2.ui.PlayerView;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.haishinkit.event.EventUtils;
@@ -214,6 +215,7 @@ public class IoniCordovaRTMPandHLS extends CordovaPlugin {
                     playerView = new PlayerView(cordova.getActivity());
                     playerView.setPlayer(exoPlayer);
                     playerView.setUseController(false);
+                    playerView.setResizeMode(AspectRatioFrameLayout.RESIZE_MODE_FILL);
 
                     MediaSource mediaSource = new HlsMediaSource.Factory(new DefaultHttpDataSource.Factory())
                             .createMediaSource(MediaItem.fromUri(Uri.parse(HLSUrl)));

--- a/src/android/IoniCordovaRTMPandHLS.java
+++ b/src/android/IoniCordovaRTMPandHLS.java
@@ -186,20 +186,23 @@ public class IoniCordovaRTMPandHLS extends CordovaPlugin {
 
     private void stopBroadcasting(CallbackContext callbackContext) {
         new AsyncTask<Void, Void, Void>() {
-            @Override
-            protected Void doInBackground(Void... voids) {
+        @Override
+        protected Void doInBackground(Void... voids) {
+            if(connection != null) {
                 connection.close();
-                stream.close();
                 connection = null;
+            }
+            if(stream != null) {
+                stream.close();
                 stream = null;
-                return null;
             }
+            return null;
+        }
 
-            @Override
-            protected void onPostExecute(Void aVoid) {
-                callbackContext.success("stopBroadcasting Executed!");
-            }
-        }.execute();
+        @Override
+        protected void onPostExecute(Void aVoid) {
+            callbackContext.success("stopBroadcasting Executed!");
+        }}.execute();
     }
 
     private void viewLiveStream(String HLSUrl, CallbackContext callbackContext) {

--- a/src/ios/IoniCordovaRTMPandHLS.swift
+++ b/src/ios/IoniCordovaRTMPandHLS.swift
@@ -135,14 +135,21 @@ import Combine
     
     @objc(stopBroadcasting:)
     func stopBroadcasting(command: CDVInvokedUrlCommand) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.stream.close()
-            self.connection.close()
+       DispatchQueue.main.async { [weak self] in
+           guard let self = self else { return }
+           if let stream = self.stream {
+               stream.close()
+               self.stream = nil
+           }
+
+           if let connection = self.connection {
+               connection.close()
+               self.connection = nil
+           }
             
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: "stopBroadcasting Executed!")
-            self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
-        }
+           let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: "stopBroadcasting Executed!")
+           self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
+       }
     }
     
     @objc(viewLiveStream:)

--- a/src/ios/IoniCordovaRTMPandHLS.swift
+++ b/src/ios/IoniCordovaRTMPandHLS.swift
@@ -33,10 +33,18 @@ import Combine
             print(error)
         }
         
+        hkView = MTHKView(frame: webView.bounds)
+        hkView.layer.zPosition = 0;
+        webView.layer.zPosition = 1;
+        hkView.videoGravity = AVLayerVideoGravity.resizeAspectFill
+        
         connection = RTMPConnection()
         connection.addEventListener(.rtmpStatus, selector: #selector(rtmpStatusHandler), observer: self, useCapture:false)
         stream = RTMPStream(connection: connection)
-
+        
+        let videoSettings = VideoCodecSettings(videoSize: VideoSize(width: Int32(hkView.frame.width), height: Int32(hkView.frame.height)));
+        stream.videoSettings = videoSettings;
+        
         stream.attachAudio(AVCaptureDevice.default(for: .audio)) { error in
             print("Error attaching audio")
         }
@@ -48,10 +56,6 @@ import Combine
         webView.isOpaque = false
         webView.backgroundColor = UIColor.clear
         viewController.view.backgroundColor = UIColor.clear
-        hkView = MTHKView(frame: webView.bounds)
-        hkView.layer.zPosition = 0;
-        webView.layer.zPosition = 1;
-        hkView.videoGravity = AVLayerVideoGravity.resizeAspectFill
         hkView.attachStream(stream)
         viewController.view.insertSubview(hkView, belowSubview: webView)
 


### PR DESCRIPTION
- (Android/iOS) Improve stopBroadcasting function to validate if the stream/connection are different null in order to close the stream/connection
- (Android) Improve the viewLivestream function and set resizeMode to fill in order for the exoPlayer fill up the playView container with playback video 