### PR TITLE
Broadcast - Improve Video Settings

### DIFF
--- a/src/android/IoniCordovaRTMPandHLS.java
+++ b/src/android/IoniCordovaRTMPandHLS.java
@@ -96,6 +96,20 @@ public class IoniCordovaRTMPandHLS extends CordovaPlugin {
 
                     connection = new RtmpConnection();
                     stream = new RtmpStream(connection);
+                    
+                    stream.getVideoSetting().setFrameRate(60);
+                    List<CodecOption> options = new ArrayList<>();
+                    CodecOption profileOption = new CodecOption("profile", "high");
+                    options.add(profileOption);
+                    CodecOption levelOption = new CodecOption("level", "5.1");
+                    options.add(levelOption);
+                    stream.getVideoSetting().setOptions(options);
+                    stream.getVideoSetting().setBitRate(8500 * 1000);
+                    stream.getVideoSetting().setIFrameInterval(2);
+                    stream.getVideoSetting().setWidth(1080);
+                    stream.getVideoSetting().setHeight(1920);
+                    stream.getAudioSetting().setBitRate(96 * 1000);
+
                     stream.attachAudio(new AudioRecordSource(context, false));
 
                     cameraSource = new Camera2Source(context, false);

--- a/src/android/IoniCordovaRTMPandHLS.java
+++ b/src/android/IoniCordovaRTMPandHLS.java
@@ -29,8 +29,12 @@ import com.haishinkit.media.AudioRecordSource;
 import com.haishinkit.media.Camera2Source;
 import com.haishinkit.rtmp.RtmpConnection;
 import com.haishinkit.rtmp.RtmpStream;
+import com.haishinkit.codec.CodecOption;
+import com.haishinkit.codec.VideoCodec;
 import com.haishinkit.view.HkSurfaceView;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class IoniCordovaRTMPandHLS extends CordovaPlugin {
     private RtmpConnection connection;

--- a/src/ios/IoniCordovaRTMPandHLS.swift
+++ b/src/ios/IoniCordovaRTMPandHLS.swift
@@ -42,8 +42,17 @@ import Combine
         connection.addEventListener(.rtmpStatus, selector: #selector(rtmpStatusHandler), observer: self, useCapture:false)
         stream = RTMPStream(connection: connection)
         
-        let videoSettings = VideoCodecSettings(videoSize: VideoSize(width: Int32(hkView.frame.width), height: Int32(hkView.frame.height)));
-        stream.videoSettings = videoSettings;
+        stream.frameRate = 60;
+        stream.sessionPreset = .hd1920x1080;
+        stream.videoSettings.videoSize = .init(width: 1080, height: 1920);
+        stream.videoSettings.profileLevel = kVTProfileLevel_H264_High_AutoLevel as String;
+        stream.videoSettings.bitRate = 8500 * 1000;
+        stream.videoSettings.maxKeyFrameIntervalDuration = 2;
+        stream.videoSettings.scalingMode = .trim;
+        stream.videoSettings.bitRateMode = .average;
+        stream.videoSettings.isHardwareEncoderEnabled = true;
+        stream.videoSettings.allowFrameReordering = false;
+        stream.audioSettings.bitRate = 96*1000;
         
         stream.attachAudio(AVCaptureDevice.default(for: .audio)) { error in
             print("Error attaching audio")

--- a/src/ios/IoniCordovaRTMPandHLS.swift
+++ b/src/ios/IoniCordovaRTMPandHLS.swift
@@ -4,7 +4,7 @@ import HaishinKit
 import AVFoundation
 import Logboard
 import Combine
-
+import VideoToolbox
 
 @objc(IoniCordovaRTMPandHLS) class IoniCordovaRTMPandHLS: CDVPlugin {
     


### PR DESCRIPTION
Improve the Video settings to use IVS recommended settings for broadcasting in both iOS/Android

- FHD Resolution - 1920x1080
- BitRate - 8500Kbps
- FPS - 60
- FrameInterval - 2 Secs